### PR TITLE
fixed pause to work with the updated infrastructure.

### DIFF
--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -167,15 +167,20 @@ export class Demo extends React.Component<DemoProps, DemoState> {
 
         if (displayBoardInstance) {
             console.log('display board instance is present. display state', displayBoardInstance.displayState)
+            displayBoardInstance.onDisplayStateChanged = this._handlePlaybackStateChanged;
             if (
-                displayBoardInstance.displayState == DisplayState.Paused ||
-                displayBoardInstance.displayState == DisplayState.Stopped
+                displayBoardInstance.displayState == DisplayState.Paused 
+                // displayBoardInstance.displayState == DisplayState.Stopped
             ) {
                 displayBoardInstance.onPlay()
             }
-        }
-
-        let table = DataManager.getInstance().table
+            else if(displayBoardInstance.displayState == DisplayState.Displaying)
+            {
+                console.log("pausing display.")
+                displayBoardInstance.onPause();
+            }
+            else{
+                let table = DataManager.getInstance().table
         console.log('table: ' + table)
         if (table) {
             // Hardcode getting the "Value" column from each data table, this will need to be set by user later
@@ -187,7 +192,11 @@ export class Demo extends React.Component<DemoProps, DemoState> {
                 demoView.onPlay(data)
             }
         }
-    }
+    
+            }
+        }
+
+        }
 
     private _handlePlaybackStateChanged = (e: DisplayState) => {
         console.log('handlePlaybackStateChanged', e)

--- a/src/sonification/displays/NoteSonify.ts
+++ b/src/sonification/displays/NoteSonify.ts
@@ -57,8 +57,9 @@ export class NoteSonify extends Sonify {
      * Start playing the current datum. This starts the oscillator again.
      */
     start() {
-        if (this.displayState == DisplayState.Stopped || this.displayState == DisplayState.Paused) {
+        if (this.displayState == DisplayState.Stopped ) {
             let oscillator = this.outputNode as OscillatorNode
+            
             oscillator?.start()
             this.playing = true
         }
@@ -90,4 +91,6 @@ export class NoteSonify extends Sonify {
         if (oscillator) return `NoteSonify playing ${oscillator.frequency.value}`
         else return `NoteSonify not currently playing`
     }
+
+    
 }


### PR DESCRIPTION
This PR implements pause to work with the updated infrastructure. Important information for the usage of pause functionality:
* The UI must handle, and hook into the DisplayBoard's onDisplayStateChanged event. We do this in demo.tsx.
* The DisplayBoard must now Handle the onSourceDataStreamEnded event for each source to know when the source stops due to the data stream for that source ending. We do this in DisplayBoard.ts.